### PR TITLE
feat: Add dpaste.org as a pastebin provider

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -119,8 +119,9 @@ function createSettingsModal() {
             </div>
             <div class="kuato-setting">
                 <label for="kuato-setting-pastebin">Pastebin Service:</label>
-                <select id="kuato-setting-pastebin" disabled>
-                    <option>fars.ee</option>
+                <select id="kuato-setting-pastebin">
+                    <option value="fars.ee">fars.ee</option>
+                    <option value="dpaste.org">dpaste.org</option>
                 </select>
             </div>
             <div class="kuato-setting">
@@ -297,6 +298,7 @@ function initializeKuato() {
 
     openSettingsButton.addEventListener('click', () => {
         document.getElementById('kuato-setting-chunk-size').value = kuatoSettings.chunkSize;
+        document.getElementById('kuato-setting-pastebin').value = kuatoSettings.pastebinService;
         document.getElementById('kuato-setting-message-format').value = kuatoSettings.messageFormat;
         settingsModal.style.display = 'flex';
     });
@@ -308,6 +310,7 @@ function initializeKuato() {
     saveSettingsButton.addEventListener('click', () => {
         const newSettings = {
             chunkSize: parseInt(document.getElementById('kuato-setting-chunk-size').value, 10),
+            pastebinService: document.getElementById('kuato-setting-pastebin').value,
             messageFormat: document.getElementById('kuato-setting-message-format').value
         };
 


### PR DESCRIPTION
This change introduces dpaste.org as an alternative pastebin service.

Key changes:
- Modified `background.js` to support multiple pastebin providers, dynamically selecting the service based on user settings.
- Updated `content.js` to enable the pastebin service dropdown in the settings modal, allowing users to choose between `fars.ee` and `dpaste.org`.
- Added unit tests in `tests.js` to verify the functionality of both pastebin providers, with mocked `fetch` responses.